### PR TITLE
Moving to using a roles list from the request context by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,12 @@ Usage
 -----
 
 The ``RoleBasedPolicy`` middleware class examines each incoming request
-and verifies the ``X-Roles`` header for the appropriate role given the request
-being made.
+and verifies the ``roles`` list from the request context; which should be
+populated by an authentication middleware. If the request context
+isn't populated with a ``roles`` list, then the middleware will fall back
+on the ``X-Roles`` header for the appropriate role given the request being made.
+Usage of the ``X-Roles`` header, is primarily used when handling authentication
+outside of the middleware stack or for development with authentication disabled.
 
 Getting Started:
 

--- a/README.rst
+++ b/README.rst
@@ -20,13 +20,19 @@ Usage
 -----
 
 The ``RoleBasedPolicy`` middleware class examines each incoming request
-and verifies the ``roles`` list from the request context dictionary; which
-should be populated by an authentication middleware. If the request context
-dictionary isn't populated with a ``roles`` list, then the middleware will
-fall back on the ``X-Roles`` header for the appropriate role given the request
-being made. Usage of the ``X-Roles`` header, is primarily used when
-handling authentication outside of the middleware stack or for development
-with authentication disabled.
+and verifies the ``roles`` list from the request context; which should be
+populated by an authentication middleware. If the request context isn't
+populated with a ``roles`` list, then the middleware will fall back on
+the ``X-Roles`` header for the appropriate role given the request being made.
+Usage of the ``X-Roles`` header, is primarily used when handling
+authentication outside of the middleware stack or for development with
+authentication disabled.
+
+Implementation Note:
+
+If the request context type isn't a dictionary, the middleware will assume
+that ``req.context`` is an Object with a ``roles`` attribute.
+
 
 Getting Started:
 

--- a/README.rst
+++ b/README.rst
@@ -20,12 +20,13 @@ Usage
 -----
 
 The ``RoleBasedPolicy`` middleware class examines each incoming request
-and verifies the ``roles`` list from the request context; which should be
-populated by an authentication middleware. If the request context
-isn't populated with a ``roles`` list, then the middleware will fall back
-on the ``X-Roles`` header for the appropriate role given the request being made.
-Usage of the ``X-Roles`` header, is primarily used when handling authentication
-outside of the middleware stack or for development with authentication disabled.
+and verifies the ``roles`` list from the request context dictionary; which
+should be populated by an authentication middleware. If the request context
+dictionary isn't populated with a ``roles`` list, then the middleware will
+fall back on the ``X-Roles`` header for the appropriate role given the request
+being made. Usage of the ``X-Roles`` header, is primarily used when
+handling authentication outside of the middleware stack or for development
+with authentication disabled.
 
 Getting Started:
 

--- a/falcon_policy/middleware.py
+++ b/falcon_policy/middleware.py
@@ -11,13 +11,18 @@ class RoleBasedPolicy(object):
 
     def process_resource(self, req, resp, resource, params):
         route = req.uri_template
-        roles_header = req.get_header('X-Roles', default='@unknown')
-        provided_roles = [role.strip() for role in roles_header.split(',')]
+
+        roles = req.context.get('roles')
+
+        # Fallback on the X-Roles Header
+        if not roles:
+            roles_header = req.get_header('X-Roles', default='@unknown')
+            roles = [role.strip() for role in roles_header.split(',')]
 
         route_policy = self.manager.policies.get(route, {})
         method_policy = route_policy.get(req.method.upper(), [])
 
-        has_role = self.manager.check_roles(provided_roles, method_policy)
+        has_role = self.manager.check_roles(roles, method_policy)
 
         if not has_role:
             raise falcon.HTTPForbidden(

--- a/falcon_policy/middleware.py
+++ b/falcon_policy/middleware.py
@@ -12,12 +12,12 @@ class RoleBasedPolicy(object):
     def process_resource(self, req, resp, resource, params):
         route = req.uri_template
 
-        if issubclass(req.context_type, dict):
+        if isinstance(req.context, dict):
             roles = req.context.get('roles')
 
         # Assume it's a direct attribute
         else:
-            roles = req.context.roles
+            roles = getattr(req.context, 'roles', None)
 
         # Fallback on the X-Roles Header
         if not roles:

--- a/falcon_policy/middleware.py
+++ b/falcon_policy/middleware.py
@@ -12,7 +12,12 @@ class RoleBasedPolicy(object):
     def process_resource(self, req, resp, resource, params):
         route = req.uri_template
 
-        roles = req.context.get('roles')
+        if issubclass(req.context_type, dict):
+            roles = req.context.get('roles')
+
+        # Assume it's a direct attribute
+        else:
+            roles = req.context.roles
 
         # Fallback on the X-Roles Header
         if not roles:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -37,19 +37,29 @@ sample_config = {
 }
 
 
-def create_req_stub(uri, method, roles_header, context=None):
+def create_req_stub(uri, method, roles_header, context=None,
+                    context_type=None):
     return stub(
         uri_template=uri,
         method=method,
         get_header=lambda name, default: roles_header,
-        context=context or {}
+        context=context or {},
+        context_type=context_type or dict,
     )
 
 
 def test_failover_to_header():
     middleware = RoleBasedPolicy(sample_config)
 
-    req_stub = create_req_stub('/plainroles', 'HEAD', '@unknown')
+    req_stub = create_req_stub('/plainroles', 'head', '@unknown')
+    middleware.process_resource(req_stub, None, None, None)
+
+
+def test_object_context_type():
+    middleware = RoleBasedPolicy(sample_config)
+    context = stub(roles=['@unknown'])
+
+    req_stub = create_req_stub('/plainroles', 'head', None, context, object)
     middleware.process_resource(req_stub, None, None, None)
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -37,65 +37,78 @@ sample_config = {
 }
 
 
-def create_req_stub(uri, method, roles_header):
+def create_req_stub(uri, method, roles_header, context=None):
     return stub(
         uri_template=uri,
         method=method,
-        get_header=lambda name, default: roles_header
+        get_header=lambda name, default: roles_header,
+        context=context or {}
     )
+
+
+def test_failover_to_header():
+    middleware = RoleBasedPolicy(sample_config)
+
+    req_stub = create_req_stub('/plainroles', 'HEAD', '@unknown')
+    middleware.process_resource(req_stub, None, None, None)
 
 
 def test_passthrough():
     middleware = RoleBasedPolicy(sample_config)
 
     # Config known route should pass through
-    req_stub = create_req_stub('/plainroles', 'HEAD', '@unknown')
+    req_stub = create_req_stub(
+        '/plainroles',
+        'HEAD',
+        None,
+        {'roles': ['@unknown']}
+    )
     middleware.process_resource(req_stub, None, None, None)
 
 
 def test_unknown_route_should_fail():
     middleware = RoleBasedPolicy(sample_config)
-    req_stub = create_req_stub('/unknown', 'put', 'admin')
+    req_stub = create_req_stub('/unknown', 'put', None, {'roles': ['admin']})
 
     with pytest.raises(falcon.HTTPForbidden):
         middleware.process_resource(req_stub, None, None, None)
 
 
-@pytest.mark.parametrize('uri, method, roles_header', [
-    ('/plainroles', 'get', 'admin'),
-    ('/withgroups', 'get', 'observer'),
-    ('/withgroups', 'get', 'creator, observer'),
-    ('/withgroups', 'get', 'invalidone, observer'),
-    ('/mixed', 'get', 'admin'),
-    ('/mixed', 'get', 'audit'),
-    ('/mixed', 'get', 'creator'),
+@pytest.mark.parametrize('uri, method, roles', [
+    ('/plainroles', 'get', ['admin']),
+    ('/withgroups', 'get', ['observer']),
+    ('/withgroups', 'get', ['creator', 'observer']),
+    ('/withgroups', 'get', ['invalidone', 'observer']),
+    ('/mixed', 'get', ['admin']),
+    ('/mixed', 'get', ['audit']),
+    ('/mixed', 'get', ['creator']),
 
     # Check the special "@any-role" built-in group
-    ('/special-any', 'get', 'admin'),
-    ('/special-any', 'get', 'creator'),
-    ('/special-any', 'get', 'observer'),
-    ('/special-any', 'get', 'audit'),
+    ('/special-any', 'get', ['admin']),
+    ('/special-any', 'get', ['creator']),
+    ('/special-any', 'get', ['observer']),
+    ('/special-any', 'get', ['audit']),
 ])
-def test_with_valid_role(uri, method, roles_header):
+def test_with_valid_role(uri, method, roles):
     middleware = RoleBasedPolicy(sample_config)
-    req_stub = create_req_stub(uri, method, roles_header)
+    req_stub = create_req_stub(uri, method, None, {'roles': roles})
 
     # Should not raise an exception
     middleware.process_resource(req_stub, None, None, None)
 
 
-@pytest.mark.parametrize('uri, method, roles_header', [
-    ('/plainroles', 'get', 'nope'),
-    ('/withgroups', 'post', 'observer'),
+@pytest.mark.parametrize('uri, method, roles', [
+    ('/plainroles', 'get', ['nope']),
+    ('/withgroups', 'post', ['observer']),
 
     # Make sure we can't use the group name
-    ('/withgroups', 'post', 'read'),
-    ('/withgroups', 'post', '@any-role'),
-    ('/withgroups', 'post', '@passthrough'),
+    ('/withgroups', 'post', ['read']),
+    ('/withgroups', 'post', ['@any-role']),
+    ('/withgroups', 'post', ['@passthrough']),
 ])
-def test_with_invalid_role(uri, method, roles_header):
+def test_with_invalid_role(uri, method, roles):
     middleware = RoleBasedPolicy(sample_config)
-    req_stub = create_req_stub(uri, method, roles_header)
+    req_stub = create_req_stub(uri, method, None, {'roles': roles})
 
     with pytest.raises(falcon.HTTPForbidden):
         middleware.process_resource(req_stub, None, None, None)


### PR DESCRIPTION
This is backwards compatible and will still pull role information from
the headers, but that method is far less ideal when handling building in
authentication within the app middleware stack.